### PR TITLE
added 50-50 ,improved "obtain powers" functionality #32 #22

### DIFF
--- a/src/main/java/com/opap/tournamentapp/model/User.java
+++ b/src/main/java/com/opap/tournamentapp/model/User.java
@@ -21,6 +21,7 @@ public class User {
     private String avatarUrl;
 
     private int correctAnswerStreak;
+
     private String item;
 
 

--- a/src/main/java/com/opap/tournamentapp/service/UserAnswerService.java
+++ b/src/main/java/com/opap/tournamentapp/service/UserAnswerService.java
@@ -98,24 +98,18 @@ public class UserAnswerService {
         User user = userRepository.findById(userId).orElse(null);
         if (user != null && isCorrect) {
             user.setCorrectAnswerStreak(user.getCorrectAnswerStreak() +1 );
-            // boost is basically double points for correct answer >=3 and triple on >=5 also win an item
-            if (user.getCorrectAnswerStreak() >= 3 ){
-                if (user.getCorrectAnswerStreak() >= 5) {
+            // boost is basically double points for correct answer >=3 and triple on >=5 also win an power
+            if (user.getCorrectAnswerStreak() > 0 ){
+                obtainPower(user); //obtain power depending on streak
+                if (user.getCorrectAnswerStreak() >= 5) { //5+
                     user.setScore((user.getScore() + 3));
-                    //obtain the power
-                    if(user.getItem()==null || Objects.equals(user.getItem(), "freeze")){
-                        user.setItem("mask");
-                    }
                 }
-                else{
+                else if(user.getCorrectAnswerStreak() >=3){ //3-4
                 user.setScore(user.getScore() +2 );
-                if(user.getItem()==null) {
-                    user.setItem("freeze");
-                }
                 }
             }
             else{
-                user.setScore(user.getScore()+1);
+                user.setScore(user.getScore()+1); //0-1-2
             }
         }
         else{
@@ -123,6 +117,22 @@ public class UserAnswerService {
             user.setCorrectAnswerStreak(0);
         }
         userRepository.save(user);
+    }
+
+    public void obtainPower(User user){
+        if(user.getCorrectAnswerStreak() % 5 ==0 ){
+                user.setItem("mask");
+        }
+        else if(user.getCorrectAnswerStreak() % 5== 1 ){
+            if(!Objects.equals(user.getItem(), "freeze") && !Objects.equals(user.getItem(),"mask")){
+                user.setItem("50-50");
+            }
+        }
+        else if (user.getCorrectAnswerStreak() % 5== 3){
+            if(!Objects.equals(user.getItem(), "mask")){
+                user.setItem("freeze");
+            }
+        }
     }
 
     public void usePower(Long userId,String item,Long enemyId) {
@@ -134,7 +144,7 @@ public class UserAnswerService {
             //secure it has the item to user power of
             if (Objects.equals(user.getItem(), item)){
                 logger.info(item);
-                if(Objects.equals(item, "mask") && !enemy.getMask_debuff()) //if the power is freeze
+                if(Objects.equals(item, "mask") && !enemy.getMask_debuff()) //if the power is mask
                 {
                     double stolenPoints=enemy.getScore()/4.0;
                     stolenPoints = Math.ceil(stolenPoints);;


### PR DESCRIPTION
**Explanation for Issues #32 #22**

**Overview:**
In this update, users gain powers dynamically based on their streak. There are three power levels: 50-50, Freeze, and Mask, earned at different stages of progress.

**Power Levels:**
1. **50-50 Power:** Users start with this power, allowing them to eliminate two incorrect options.
2. **Freeze Power:** Unlocked after three consecutive correct answers, users freeze their opponent ending their strike.
3. **Mask Power:** Achieved after five correct answers, users can steal points from their opponents (1/4 of their points)

**Streak Bonus:**
Users who maintain a streak beyond five correct answers enter a streak loop, earning the powers all over again .
For example if they answer 6 correct and they have used "mask" which earned on 5 correct they obtain 50-50 again.
Now, if they didn't use mask  it does not override because mask is stronger than 50-50 (I explain power levels below)

**Power levels for override**
50-50 < Freeze < Mask
If a user consistently performs well, their power level upgrades automatically. The strongest power prevails.

